### PR TITLE
Issue#11 Add support for running tests from the npm test command.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "CommunityCalendar",
+  "name": "bower",
   "version": "0.1",
   "private": true,
   "ignore": [
@@ -11,6 +11,9 @@
   ],
   "dependencies": {
     "angular": "",
-    "angular-route": "~1.4.8"
+    "angular-route": "~1.4.8",
+    "angular-ui-router": "",
+    "angular-bootstrap": "",
+    "bootstrap": ""
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
   },
   "scripts": {
-    "postinstall": "bower install"
+    "postinstall": "bower install",
+    "test": "jasmine-node --verbose test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "body-parser": "",
     "serve-static": "",
     "errorhandler": "",
-    "bower": ""
+    "bower": "",
+    "jasmine-node": "",
+    "frisby": "",
+    "karma": ""
   },
   "production_dirs": {
     "coffee_src": "src/",

--- a/test/e2e/runner.html
+++ b/test/e2e/runner.html
@@ -4,6 +4,7 @@
 		<title>End2end Test Runner</title>
 		<meta charset="utf-8">
 		<script src="../lib/angular/angular-scenario.js" ng-autotest></script>
+		<script src="../lib/angular/angular-mocks.js" ng-autotest></script>
 		<script src="scenarios.js"></script>
 	</head>
 	<body>

--- a/test/e2e/seed-runner.html
+++ b/test/e2e/seed-runner.html
@@ -4,6 +4,7 @@
     <title>End2end Test Runner</title>
     <meta charset="utf-8">
     <script src="../lib/angular/angular-scenario.js" ng-autotest></script>
+    <script src="../lib/angular/angular-mocks.js" ng-autotest></script>
     <script src="seed-scenarios.js"></script>
   </head>
   <body>


### PR DESCRIPTION
The command to execute tests is `jasmine-node scripts/`. Now the tests can be performed using the `npm test` command too.
